### PR TITLE
Residual pwn* files.

### DIFF
--- a/AutoSUID.sh
+++ b/AutoSUID.sh
@@ -289,6 +289,8 @@ done;
 if [ -z "$exploitablesuidarray" ]
 then
 	echo -e "$RED_BOLD[ - ]$CLEAR_FONT Unfortunately, there are no any SUID files, which lead to privilege escalation";
+	## Clean residual pwn* files
+	rm pwn*
 	exit
 fi
 


### PR DESCRIPTION
The script doesn't delete residual pwn* files when any found SUID files leads to escalation.